### PR TITLE
Clean up and simplify

### DIFF
--- a/napari/_tests/test_magicgui.py
+++ b/napari/_tests/test_magicgui.py
@@ -282,9 +282,6 @@ def test_magicgui_get_viewer(make_napari_viewer):
 
 MGUI_EXPORTS = ['napari.layers.Layer', 'napari.Viewer']
 MGUI_EXPORTS += [f'napari.types.{nm.title()}Data' for nm in layers.NAMES]
-MGUI_EXPORTS.remove(
-    'napari.types.AsyncimageData'
-)  # temporary for async slicing
 NAMES = ('Image', 'Labels', 'Layer', 'Points', 'Shapes', 'Surface')
 
 

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -6,9 +6,8 @@ import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict, namedtuple
 from contextlib import contextmanager
-from dataclasses import dataclass, field, fields
 from functools import cached_property
-from typing import Any, List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import magicgui as mgui
 import numpy as np
@@ -1877,34 +1876,3 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
 
 
 mgui.register_type(type_=List[Layer], return_callback=add_layers_to_viewer)
-
-
-@dataclass(frozen=True)
-class _LayerSliceRequest:
-    data: Any = field(repr=False)
-    data_to_world: Affine = field(repr=False)
-    ndim: int
-    ndisplay: int
-    point: Tuple[float, ...]
-    dims_order: Tuple[int, ...]
-    dims_displayed: Tuple[int, ...] = field(repr=False)
-    dims_not_displayed: Tuple[int, ...] = field(repr=False)
-    multiscale: bool = field(repr=False)
-    corner_pixels: np.ndarray
-    round_index: bool = field(repr=False)
-    # dask_config: DaskIndexer = field(repr=False)
-
-    def asdict(self) -> dict:
-        """Shallow copy of the request as a dict.
-        From the official Python docs: https://docs.python.org/3/library/dataclasses.html#dataclasses.asdict
-        """
-        return {
-            field.name: getattr(self, field.name) for field in fields(self)
-        }
-
-
-@dataclass(frozen=True)
-class _LayerSliceResponse:
-    request: _LayerSliceRequest
-    data: Any = field(repr=False)
-    data_to_world: Affine = field(repr=False)

--- a/napari/types.py
+++ b/napari/types.py
@@ -108,9 +108,6 @@ else:
 
 
 ImageData = NewType("ImageData", ArrayBase)
-AsyncimageData = NewType(
-    "AsyncimageData", ArrayBase
-)  # TODO temporary for async buildout
 LabelsData = NewType("LabelsData", ArrayBase)
 PointsData = NewType("PointsData", ArrayBase)
 ShapesData = NewType("ShapesData", List[ArrayBase])


### PR DESCRIPTION
# Description

I did some more clean up and simplification (hopefully!) after our code pair today.

I relaxed some of the typing (which I think is OK for now) and also defined fake sync and async layers that keep track of how many times their respective slice functions have been called, which improved some of the tests we wrote (again, hopefully!).

Some good follow-up tasks after this.

- Add more cases for cancellation
- Add more cases for a mixture of async and sync layers
- Make the slicer a fixture and call shutdown automatically on teardown
- Maybe use some standard mock tools instead of the fake layer classes if/where appropriate.
