### PR TITLE
Add force sync slicing

### DIFF
--- a/napari/components/_tests/test_layer_slicer.py
+++ b/napari/components/_tests/test_layer_slicer.py
@@ -267,3 +267,13 @@ def test_await_slice_blocked_timeout(layer_slicer):
         blocked = layer_slicer.slice_layers_async(layers=[layer], dims=dims)
         with pytest.raises(TimeoutError):
             layer_slicer.await_slice(future=blocked, timeout=timeout)
+
+
+def test_wait_until_idle(layer_slicer):
+    dims = Dims()
+    layer = FakeAsyncLayer()
+
+    layer_slicer.slice_layers_async(layers=[layer], dims=dims)
+    # depending on speed of execution, this may or may not pick up active futures
+    layer_slicer.wait_until_idle()
+    assert not layer_slicer._layers_to_task

--- a/napari/components/_tests/test_layer_slicer.py
+++ b/napari/components/_tests/test_layer_slicer.py
@@ -244,3 +244,19 @@ def test_slice_layers_async_task_to_layers_lock(layer_slicer):
 
     assert task.result()[layer].id == 1
     assert task not in layer_slicer._layers_to_task
+
+
+def test_slice_layers_async_await(layer_slicer):
+    dims = Dims()
+    layer = FakeAsyncLayer()
+
+    assert layer.slice_count == 0
+    with layer.lock:
+        blocked = layer_slicer.slice_layers_async(layers=[layer], dims=dims)
+        assert not blocked.done()
+
+    layer_slicer.await_slice(
+        timeout=5
+    )  # TODO this is a terrible test, come up with something else
+
+    assert blocked.result()[layer].id == 1


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->
Adds ability to force synchronous slicing for a single event, or across all slices from an instance of `Layer_Slicer`. 

Adds a public await function to allow users to wait until slicing is complete before moving forward with their code (e.g. for screenshot grabs). 


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
