### PR TITLE
Add some old async definitions back

### DIFF
--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -54,10 +54,6 @@ jobs:
             platform: ubuntu-20.04
             backend: pyqt5
             MIN_REQ: 1
-          # test with --async_only
-          - python: 3.8
-            platform: ubuntu-20.04
-            toxenv: async-py38-linux-pyqt5
           # test without any Qt backends
           - python: 3.8
             platform: ubuntu-20.04

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -79,10 +79,6 @@ jobs:
             platform: ubuntu-20.04
             backend: pyqt5
             MIN_REQ: 1
-          # test with --async_only
-          - python: 3.8
-            platform: ubuntu-20.04
-            toxenv: async-pyqt5-py38-linux
           # test without any Qt backends
           - python: 3.8
             platform: ubuntu-20.04

--- a/napari/_qt/_tests/test_async_slicing.py
+++ b/napari/_qt/_tests/test_async_slicing.py
@@ -17,7 +17,6 @@ def rng() -> np.random.Generator:
     return np.random.default_rng(0)
 
 
-@pytest.mark.async_only
 def test_async_slice_image_on_current_step_change(
     make_napari_viewer, qtbot, rng
 ):
@@ -31,7 +30,6 @@ def test_async_slice_image_on_current_step_change(
     wait_until_vispy_image_data_equal(qtbot, vispy_image, data[2, :, :])
 
 
-@pytest.mark.async_only
 def test_async_slice_image_on_order_change(make_napari_viewer, qtbot, rng):
     viewer = make_napari_viewer()
     data = rng.random((3, 4, 5))
@@ -43,7 +41,6 @@ def test_async_slice_image_on_order_change(make_napari_viewer, qtbot, rng):
     wait_until_vispy_image_data_equal(qtbot, vispy_image, data[:, 2, :])
 
 
-@pytest.mark.async_only
 def test_async_slice_image_on_ndisplay_change(make_napari_viewer, qtbot, rng):
     viewer = make_napari_viewer()
     data = rng.random((3, 4, 5))
@@ -55,7 +52,6 @@ def test_async_slice_image_on_ndisplay_change(make_napari_viewer, qtbot, rng):
     wait_until_vispy_image_data_equal(qtbot, vispy_image, data)
 
 
-@pytest.mark.async_only
 def test_async_slice_multiscale_image_on_pan(make_napari_viewer, qtbot, rng):
     viewer = make_napari_viewer()
     data = [rng.random((4, 8, 10)), rng.random((2, 4, 5))]
@@ -77,7 +73,6 @@ def test_async_slice_multiscale_image_on_pan(make_napari_viewer, qtbot, rng):
     wait_until_vispy_image_data_equal(qtbot, vispy_image, data[1][1, 0:4, 0:3])
 
 
-@pytest.mark.async_only
 def test_async_slice_multiscale_image_on_zoom(qtbot, make_napari_viewer, rng):
     viewer = make_napari_viewer()
     data = [rng.random((4, 8, 10)), rng.random((2, 4, 5))]

--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -267,7 +267,6 @@ def test_notification_error(count_show, monkeypatch):
 
 
 @skip_on_win_ci
-@pytest.mark.sync_only
 def test_notifications_error_with_threading(
     make_napari_viewer, clean_current, monkeypatch
 ):

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -293,6 +293,17 @@ class QtViewer(QSplitter):
         for overlay in self.viewer._overlays.values():
             self._add_overlay(overlay)
 
+    @property
+    def chunk_receiver(self) -> None:
+        warnings.warn(
+            trans._(
+                'QtViewer.chunk_receiver is deprecated from napari version 0.5 and will be removed in a later version.'
+            ),
+            DeprecationWarning,
+            stacklevel=1,
+        )
+        return None
+
     @staticmethod
     def _update_dask_cache_settings(
         dask_setting: Union[DaskSettings, Event] = None

--- a/napari/_tests/test_magicgui.py
+++ b/napari/_tests/test_magicgui.py
@@ -119,7 +119,6 @@ def test_magicgui_add_future_data(
     _assert_stuff()
 
 
-@pytest.mark.sync_only
 def test_magicgui_add_threadworker(qtbot, make_napari_viewer):
     """Test that annotating with FunctionWorker works."""
     from napari.qt.threading import FunctionWorker, thread_worker

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -214,9 +214,6 @@ def test_changing_theme(make_napari_viewer):
         viewer.theme = 'nonexistent_theme'
 
 
-# TODO: revisit the need for sync_only here.
-# An async failure was observed here on CI, but was not reproduced locally
-# @pytest.mark.sync_only
 @pytest.mark.parametrize('layer_class, data, ndim', layer_test_data)
 def test_roll_transpose_update(make_napari_viewer, layer_class, data, ndim):
     """Check that transpose and roll preserve correct transform sequence."""

--- a/napari/components/experimental/chunk/__init__.py
+++ b/napari/components/experimental/chunk/__init__.py
@@ -1,22 +1,22 @@
 """chunk module"""
-# from napari.components.experimental.chunk._loader import (
-#     chunk_loader,
-#     synchronous_loading,
-#     wait_for_async,
-# )
-# from napari.components.experimental.chunk._request import (
-#     ChunkLocation,
-#     ChunkRequest,
-#     LayerRef,
-#     OctreeLocation,
-# )
+from napari.components.experimental.chunk._loader import (
+    chunk_loader,
+    synchronous_loading,
+    wait_for_async,
+)
+from napari.components.experimental.chunk._request import (
+    ChunkLocation,
+    ChunkRequest,
+    LayerRef,
+    OctreeLocation,
+)
 
-# __all__ = [
-#     'ChunkLocation',
-#     'OctreeLocation',
-#     'ChunkRequest',
-#     'LayerRef',
-#     'chunk_loader',
-#     'wait_for_async',
-#     'synchronous_loading',
-# ]
+__all__ = [
+    'ChunkLocation',
+    'OctreeLocation',
+    'ChunkRequest',
+    'LayerRef',
+    'chunk_loader',
+    'wait_for_async',
+    'synchronous_loading',
+]

--- a/napari/components/experimental/chunk/_commands/__init__.py
+++ b/napari/components/experimental/chunk/_commands/__init__.py
@@ -1,7 +1,7 @@
 """Commands for napari's IPython console."""
 
-# from napari.components.experimental.chunk._commands._loader import (
-#     LoaderCommands,
-# )
+from napari.components.experimental.chunk._commands._loader import (
+    LoaderCommands,
+)
 
-# __all__ = ["LoaderCommands"]
+__all__ = ["LoaderCommands"]

--- a/napari/components/experimental/chunk/_loader.py
+++ b/napari/components/experimental/chunk/_loader.py
@@ -14,8 +14,7 @@ from napari.components.experimental.chunk._cache import ChunkCache
 from napari.components.experimental.chunk._info import LayerInfo, LoadType
 from napari.components.experimental.chunk._pool_group import LoaderPoolGroup
 from napari.components.experimental.chunk._request import ChunkRequest
-
-# from napari.utils.config import octree_config  # REMOVED
+from napari.utils.config import octree_config
 from napari.utils.events import EmitterGroup
 
 LOGGER = logging.getLogger("napari.loader")
@@ -38,21 +37,19 @@ class ChunkLoader:
     """
 
     def __init__(self) -> None:
-        _setup_logging(octree_config)  # noqa: F821
+        _setup_logging(octree_config)
 
-        loader_config = octree_config['loader_defaults']  # noqa: F821
+        loader_config = octree_config['loader_defaults']
 
         self.force_synchronous: bool = bool(loader_config['force_synchronous'])
         self.auto_sync_ms = loader_config['auto_sync_ms']
-        self.octree_enabled = octree_config['octree']['enabled']  # noqa: F821
+        self.octree_enabled = octree_config['octree']['enabled']
 
         self.layer_map: Dict[int, LayerInfo] = {}
         self.cache: ChunkCache = ChunkCache()
 
         self.events = EmitterGroup(source=self, chunk_loaded=None)
-        self._loaders = LoaderPoolGroup(
-            octree_config, self._on_done  # noqa: F821
-        )
+        self._loaders = LoaderPoolGroup(octree_config, self._on_done)
 
     def get_info(self, layer_id: int) -> Optional[LayerInfo]:
         """Get LayerInfo for this layer or None.
@@ -395,5 +392,4 @@ Think of the ChunkLoader as a shared resource like "the filesystem" where
 multiple clients can be access it at the same time, but it is the interface
 to just one physical resource.
 """
-# chunk_loader = ChunkLoader() if octree_config else None # Removed octree
-chunk_loader = None
+chunk_loader = ChunkLoader() if octree_config else None

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -57,28 +57,6 @@ if TYPE_CHECKING:
     from npe2._pytest_plugin import TestPluginManager
 
 
-def pytest_addoption(parser):
-    """Add napari specific command line options.
-
-    --aysnc_only
-        Run only asynchronous tests, not sync ones. This is the same as
-        `pytest napari -m async_only`. It is slower but this is how tox skips
-        these tests.
-
-    Notes
-    -----
-    Due to the placement of this conftest.py file, you must specifically name
-    the napari folder such as "pytest napari --async_only"
-    """
-
-    parser.addoption(
-        "--async_only",
-        action="store_true",
-        default=False,
-        help="run only asynchronous tests",
-    )
-
-
 @pytest.fixture
 def layer_data_and_types():
     """Fixture that provides some layers and filenames
@@ -347,7 +325,6 @@ def pytest_generate_tests(metafunc):
 
 
 def pytest_collection_modifyitems(session, config, items):
-    skip_non_async = pytest.mark.skip(reason="only running async tests")
     test_order_prefix = [
         os.path.join("napari", "utils"),
         os.path.join("napari", "layers"),
@@ -363,10 +340,6 @@ def pytest_collection_modifyitems(session, config, items):
     test_order = [[] for _ in test_order_prefix]
     test_order.append([])  # for not matching tests
     for item in items:
-        if config.getoption("--async_only") and not item.get_closest_marker(
-            'async_only'
-        ):
-            item.add_marker(skip_non_async)
         index = -1
         for i, prefix in enumerate(test_order_prefix):
             if prefix in str(item.fspath):

--- a/napari/experimental/__init__.py
+++ b/napari/experimental/__init__.py
@@ -12,6 +12,6 @@ __all__ = [
     'chunk_loader',
     'link_layers',
     'layers_linked',
-    'unlink_layers',
     'synchronous_loading',
+    'unlink_layers',
 ]

--- a/napari/experimental/__init__.py
+++ b/napari/experimental/__init__.py
@@ -1,3 +1,7 @@
+from napari.components.experimental.chunk import (
+    chunk_loader,
+    synchronous_loading,
+)
 from napari.layers.utils._link_layers import (
     layers_linked,
     link_layers,
@@ -5,7 +9,9 @@ from napari.layers.utils._link_layers import (
 )
 
 __all__ = [
+    'chunk_loader',
     'link_layers',
     'layers_linked',
     'unlink_layers',
+    'synchronous_loading',
 ]

--- a/napari/layers/_tests/test_dask_layers.py
+++ b/napari/layers/_tests/test_dask_layers.py
@@ -10,7 +10,6 @@ from napari.components import ViewerModel
 from napari.utils import _dask_utils, resize_dask_cache
 
 
-# @pytest.mark.sync_only
 @pytest.mark.parametrize('dtype', ['float64', 'uint8'])
 def test_dask_not_greedy(dtype):
     """Make sure that we don't immediately calculate dask arrays."""
@@ -108,7 +107,6 @@ def delayed_dask_stack():
     return output
 
 
-# @pytest.mark.sync_only
 def test_dask_global_optimized_slicing(delayed_dask_stack, monkeypatch):
     """Test that dask_configure reduces compute with dask stacks."""
 
@@ -150,7 +148,6 @@ def test_dask_global_optimized_slicing(delayed_dask_stack, monkeypatch):
     assert delayed_dask_stack['calls'] == 5
 
 
-# @pytest.mark.sync_only
 def test_dask_unoptimized_slicing(delayed_dask_stack, monkeypatch):
     """Prove that the dask_configure function works with a counterexample."""
     # we start with a cache...but then intentionally turn it off per-layer.
@@ -191,7 +188,6 @@ def test_dask_unoptimized_slicing(delayed_dask_stack, monkeypatch):
     assert delayed_dask_stack['calls'] >= 9
 
 
-# @pytest.mark.sync_only
 def test_dask_local_unoptimized_slicing(delayed_dask_stack, monkeypatch):
     """Prove that the dask_configure function works with a counterexample."""
     # make sure we are not caching for this test, which also tests that we
@@ -232,7 +228,6 @@ def test_dask_local_unoptimized_slicing(delayed_dask_stack, monkeypatch):
     assert delayed_dask_stack['calls'] >= 10
 
 
-# @pytest.mark.sync_only
 def test_dask_cache_resizing(delayed_dask_stack):
     """Test that we can spin up, resize, and spin down the cache."""
 
@@ -289,7 +284,6 @@ def test_prevent_dask_cache(delayed_dask_stack):
     assert len(_dask_utils._DASK_CACHE.cache.heap.heap) == 0
 
 
-# @pytest.mark.sync_only
 def test_dask_contrast_limits_range_init():
     np_arr = np.array([[0.000001, -0.0002], [0, 0.0000004]])
     da_arr = da.array(np_arr)

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -525,6 +525,14 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         return self._source
 
     @property
+    def loaded(self) -> bool:
+        """Return True if this layer is fully loaded in memory.
+        This base class says that layers are permanently in the loaded state.
+        Derived classes that do asynchronous loading can override this.
+        """
+        return True
+
+    @property
     def opacity(self):
         """float: Opacity value between 0.0 and 1.0."""
         return self._opacity

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -531,7 +531,13 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         This base class says that layers are permanently in the loaded state.
         Derived classes that do asynchronous loading can override this.
         """
-        # TODO: deprecate?
+        warnings.warn(
+            trans._(
+                'Layer.loaded is deprecated from napari version 0.5 and will be removed in a later version.'
+            ),
+            DeprecationWarning,
+            stacklevel=1,
+        )
         return True
 
     @property

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -527,9 +527,11 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
     @property
     def loaded(self) -> bool:
         """Return True if this layer is fully loaded in memory.
+
         This base class says that layers are permanently in the loaded state.
         Derived classes that do asynchronous loading can override this.
         """
+        # TODO: deprecate?
         return True
 
     @property

--- a/napari/layers/image/_image_loader.py
+++ b/napari/layers/image/_image_loader.py
@@ -6,8 +6,6 @@ from napari.layers.image._image_slice_data import ImageSliceData
 class ImageLoader:
     """The default synchronous ImageLoader."""
 
-    # TODO: this whole class can be deprecated.
-
     def load(self, data: ImageSliceData) -> bool:
         """Load the ImageSliceData synchronously.
 
@@ -22,6 +20,7 @@ class ImageLoader:
             True if load happened synchronously.
         """
         data.load_sync()
+        return True
 
     def match(self, data: ImageSliceData) -> bool:
         """Return True if data matches what we are loading.

--- a/napari/layers/image/_image_slice.py
+++ b/napari/layers/image/_image_slice.py
@@ -51,11 +51,12 @@ class ImageSlice:
         self.image: ImageView = ImageView(image, image_converter)
         self.thumbnail: ImageView = ImageView(image, image_converter)
         self.rgb = rgb
+        self.loader = ImageLoader()
+
         # With async there can be a gap between when the ImageSlice is
         # created and the data is actually loaded. However initialize
         # as True in case we aren't even doing async loading.
         self.loaded = True
-        self.loader = ImageLoader()
 
     def _set_raw_images(
         self, image: ArrayLike, thumbnail_source: ArrayLike
@@ -123,5 +124,4 @@ class ImageSlice:
         # Display the newly loaded data.
         self._set_raw_images(data.image, data.thumbnail_source)
         self.loaded = True
-
         return True  # data was used.

--- a/napari/layers/image/_image_slice.py
+++ b/napari/layers/image/_image_slice.py
@@ -51,6 +51,10 @@ class ImageSlice:
         self.image: ImageView = ImageView(image, image_converter)
         self.thumbnail: ImageView = ImageView(image, image_converter)
         self.rgb = rgb
+        # With async there can be a gap between when the ImageSlice is
+        # created and the data is actually loaded. However initialize
+        # as True in case we aren't even doing async loading.
+        self.loaded = True
         self.loader = ImageLoader()
 
     def _set_raw_images(
@@ -97,6 +101,7 @@ class ImageSlice:
         bool
             Return True if load was synchronous.
         """
+        self.loaded = False  # False until self._on_loaded is calls
         return self.loader.load(data)
 
     def on_loaded(self, data: ImageSliceData) -> bool:
@@ -117,5 +122,6 @@ class ImageSlice:
 
         # Display the newly loaded data.
         self._set_raw_images(data.image, data.thumbnail_source)
+        self.loaded = True
 
         return True  # data was used.

--- a/napari/layers/utils/_tests/test_link_layers.py
+++ b/napari/layers/utils/_tests/test_link_layers.py
@@ -26,6 +26,7 @@ IM_ATTRS = {
 }
 
 
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 @pytest.mark.parametrize('key, value', {**BASE_ATTRS, **IM_ATTRS}.items())
 def test_link_image_layers_all_attributes(key, value):
     """Test linking common attributes across layers of similar types."""
@@ -41,6 +42,7 @@ def test_link_image_layers_all_attributes(key, value):
     assert getattr(l1, key) == getattr(l2, key) == value
 
 
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 @pytest.mark.parametrize('key, value', BASE_ATTRS.items())
 def test_link_different_type_layers_all_attributes(key, value):
     """Test linking common attributes across layers of different types."""
@@ -63,6 +65,7 @@ def test_link_invalid_param():
     assert "Cannot link attributes that are not shared by all layers" in str(e)
 
 
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_double_linking_noop():
     """Test that linking already linked layers is a noop."""
     l1 = layers.Points(None)
@@ -80,6 +83,7 @@ def test_double_linking_noop():
     assert len(l1.events.opacity.callbacks) == 2
 
 
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_removed_linked_target():
     """Test that linking already linked layers is a noop."""
     l1 = layers.Points(None)
@@ -109,6 +113,7 @@ def test_context_manager():
     assert len(l1.events.opacity.callbacks) == 0
 
 
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_unlink_layers():
     """Test that we can unlink layers."""
     l1 = layers.Points(None)
@@ -134,6 +139,7 @@ def test_unlink_layers():
     assert len(l3.events.blending.callbacks) == 0
 
 
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_unlink_single_layer():
     """Test that we can unlink a single layer from all others."""
     l1 = layers.Points(None)
@@ -156,6 +162,7 @@ def test_unlink_single_layer():
     assert not l1.events.blending.callbacks
 
 
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_mode_recursion():
     l1 = layers.Points(None, name='l1')
     l2 = layers.Points(None, name='l2')

--- a/napari/utils/config.py
+++ b/napari/utils/config.py
@@ -1,6 +1,9 @@
 """Napari Configuration.
 """
 import os
+import warnings
+
+from napari.utils.translations import trans
 
 
 def _set(env_var: str) -> bool:
@@ -17,12 +20,53 @@ def _set(env_var: str) -> bool:
 """
 Experimental Features
 
+Async Loading
+-------------
+Deprecated.
+
+Octree Rendering
+----------------
+Deprecated.
+
 Shared Memory Server
 --------------------
 Experimental shared memory service. Only enabled if NAPARI_MON is set to
 the path of a config file. See this PR for more info:
 https://github.com/napari/napari/pull/1909.
 """
+
+
+def _warn_about_deprecated_attribute(name) -> None:
+    warnings.warn(
+        trans._(
+            '{name} is deprecated from napari version 0.5 and will be removed in the later version.',
+            name=name,
+        ),
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+
+# Handle old async/octree deprecated attributes by returning their
+# fixed values in the module level __getattr__
+# https://peps.python.org/pep-0562/
+# Other module attributes are defined as normal.
+def __getattr__(name):
+    if name == 'octree_config':
+        _warn_about_deprecated_attribute(name)
+        return None
+    elif name in ('async_loading', 'async_octree'):
+        _warn_about_deprecated_attribute(name)
+        # For async_loading, we could get the value of the remaining
+        # async setting. We do not because that is dynamic, so will not
+        # handle an import of the form
+        #
+        # `from napari.utils.config import async_loading`
+        #
+        # consistently. Instead, we let this attribute effectively
+        # refer to the old async which is always off in napari now.
+        return False
+
 
 # Shared Memory Server
 monitor = _set("NAPARI_MON")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,6 @@ filterwarnings = [
   "error:::napari", # turn warnings from napari into errors
   "error:::test_.*", # turn warnings in our own tests into errors
   "default:::napari.+vendored.+",  # just print warnings inside vendored modules
-  "ignore:Restart required for this change:UserWarning:napari",  # triggered by a lot of async tests
   "ignore::DeprecationWarning:shibokensupport",
   "ignore::DeprecationWarning:ipykernel",
   "ignore::DeprecationWarning:tensorstore",
@@ -159,8 +158,6 @@ filterwarnings = [
   "ignore:There is no current event loop:DeprecationWarning:",
 ]
 markers = [
-    "sync_only: Test should only be run synchronously",
-    "async_only: Test should only be run asynchronously",
     "examples: Test of examples",
     "disable_qthread_start: Disable thread start in this Test",
     "disable_qthread_pool_start: Disable strarting QRunnable using QThreadPool start in this Test",

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@
 # to run a specific test, use the "tox -e" option, for instance:
 # "tox -e py38-macos-pyqt" will test python3.8 with pyqt on macos
 # (even if a combination of factors is not in the default envlist
-# you can run it manually... like py39-linux-pyside2-async)
+# you can run it manually... like py39-linux-pyside2)
 envlist = py{38,39,310}-{linux,macos,windows}-{pyqt5,pyside2,pyqt6,pyside6}
 isolated_build = true
 toxworkdir=/tmp/.tox
@@ -72,9 +72,6 @@ passenv =
 # the tox environment being run
 setenv =
     PYTHONPATH = {toxinidir}
-    async: NAPARI_ASYNC = 1
-    async: PYTEST_ADDOPTS = --async_only
-    async: PYTEST_PATH = napari
 deps =
     pytest-cov
     pyqt6: PyQt6


### PR DESCRIPTION
These changes represent most of the changes we settled on after code pairing. Haven't thought all of these through yet, but wanted to share and also run CI to see what breaks.

Overall, I am starting to feel like just removing everything old async/octree is the way to go since, like you said (and now I've felt first-hand), there is some complicated nuance here. And I'm not convinced that any discoverability of the old code being in the repo is worth it - actually I might argue that removing everything at once makes things easier to understand retrospectively too.